### PR TITLE
Inherit default grid style from matplotlib.rcParams

### DIFF
--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -8,6 +8,7 @@ import numpy as np
 from matplotlib.ticker import Formatter
 from matplotlib.transforms import Affine2D, ScaledTranslation
 from matplotlib.patches import PathPatch
+from matplotlib import rcParams
 
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 from .ticks import Ticks
@@ -68,8 +69,28 @@ class CoordinateHelper(object):
 
         # Initialize container for the grid lines
         self.grid_lines = []
+
+        # Initialize grid style. Take defaults from matplotlib.rcParams.
+        # Based on matplotlib.axis.YTick._get_gridline.
+        #
+        # Matplotlib's gridlines use Line2D, but ours use PathPatch.
+        # Patches take a slightly different format of linestyle argument.
+        lines_to_patches_linestyle = {
+            '-': 'solid',
+            '--': 'dashed',
+            '-.': 'dashdot',
+            ':': 'dotted',
+            'none': 'none',
+            'None': 'none',
+            ' ': 'none',
+            '': 'none'
+        }
         self.grid_lines_kwargs = {'visible':False,
                                   'facecolor':'none',
+                                  'edgecolor': rcParams['grid.color'],
+                                  'linestyle': lines_to_patches_linestyle[rcParams['grid.linestyle']],
+                                  'linewidth': rcParams['grid.linewidth'],
+                                  'alpha': rcParams['grid.alpha'],
                                   'transform':self.parent_axes.transData}
 
     def grid(self, draw_grid=True, grid_type='lines', **kwargs):


### PR DESCRIPTION
Based on `matplotlib.axis.YTick._get_gridline`. Note that Matplotlib implements gridlines with `Line2D`, whereas wcsaxes implements gridlines with `PathPatch`. The two have slightly different option styles regarding dashes, so we have to map between them.
