### PR TITLE
fixed ticks_labels_grid

### DIFF
--- a/docs/ticks_labels_grid.rst
+++ b/docs/ticks_labels_grid.rst
@@ -19,7 +19,7 @@ For the example in the following page we start from the example introduced in
 
     from wcsaxes import WCSAxes
 
-    ax = WCSAxes(fig, [0.25, 0.25, 0.7, 0.7], wcs=wcs)
+    ax = WCSAxes(fig, [0.2, 0.2, 0.6, 0.6], wcs=wcs)
     fig.add_axes(ax)  # note that the axes have to be added to the figure
 
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, cmap=plt.cm.gist_heat,
@@ -58,14 +58,16 @@ would use ``ra`` and ``dec``. The names are only available for specific
 celestial coordinate systems - for all other systems, you should use the index
 of the coordinate (``0`` or ``1``).
 
-Each coordinate is an instance of the :class:`~wcsaxes.coordinate_helpers.CoordinateHelper`
-class, which can be used to control the appearance of the ticks, tick labels,
-grid lines, and axis labels associated with that coordinate.
+Each coordinate is an instance of the
+:class:`~wcsaxes.coordinate_helpers.CoordinateHelper` class, which can be used
+to control the appearance of the ticks, tick labels, grid lines, and axis
+labels associated with that coordinate.
 
 Axis labels
 ===========
 
-Axis labels can be added using the :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_axislabel` method:
+Axis labels can be added using the
+:meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_axislabel` method:
 
 .. plot::
    :context:
@@ -87,6 +89,8 @@ allowed.
 
     lon.set_axislabel('Galactic Longitude', minpad=0.3)
     lat.set_axislabel('Galactic Latitude', minpad=-0.4)
+
+.. _tick_label_format:
 
 Tick label format
 =================
@@ -137,28 +141,24 @@ want to be able to manually specify the spacing. This can be done using the
 :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks` method. There
 are different options that can be used:
 
-* Set the tick positions manually::
+* Set the tick positions manually as an Astropy :class:`~astropy.units.quantity.Quantity`::
 
-      lon.set_ticks([242.2, 242.3, 242.4])
+      from astropy import units as u
+      lon.set_ticks([242.2, 242.3, 242.4] * u.degree)
 
-* Set the spacing between ticks::
+* Set the spacing between ticks also as an Astropy :class:`~astropy.units.quantity.Quantity`::
 
-      lon.set_ticks(spacing=0.1)
+      lon.set_ticks(spacing=5. * u.arcmin)
 
 * Set the approximate number of ticks::
 
       lon.set_ticks(number=4)
 
-In the case of angular axes, you should specify the spacing as an Astropy
-:class:`~astropy.units.quantity.Quantity`::
-
-      from astropy import units as u
-      lon.set_ticks(spacing=5. * u.arcmin)
-
-This is to avoid roundoff errors. The
-:meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks` method can also
-be used to set the appearance (color and size) of the ticks, using the
-``color=`` and ``size=`` options.
+In the case of angular axes, specifying the spacing as an Astropy :class:`~astropy.units.quantity.Quantity`
+avoids roundoff errors. The
+:meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks` method can also be used to set the
+appearance (color and size) of the ticks, using the ``color=`` and ``size=``
+options.
 
 We can apply this to the previous example:
 


### PR DESCRIPTION
I think I'd forgotten to pull the most recent changes to the docs to the padding branch, so the doc for ticks, labels grids is now an older version. Some of the axis labels are still outside the displayed images. This fixes both issues.
