### PR TITLE
changed ticks etc doc so that axis labels are displayed

### DIFF
--- a/docs/ticks_labels_grid.rst
+++ b/docs/ticks_labels_grid.rst
@@ -103,10 +103,8 @@ allowed.
 Tick label format
 =================
 
-The format of the tick labels can be specified with the
-:meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_major_formatter` 
-method. This method accepts either a standard Matplotlib ``Formatter`` object,
-or a string describing the format:
+The format of the tick labels can be specified with a string describing the
+format:
 
 .. plot::
    :context:


### PR DESCRIPTION
Currently in http://wcsaxes.readthedocs.org/en/latest/ticks_labels_grid.html some axis and tick labels are still outside images. Instead of changing the size of the rectangles (the only way all the labels show up is if the images are really small), I figured changing the labels was a better idea. This still demonstrates the ability of `set_major_formatter`.
