### PR TITLE
Improve handling of get_set_[xy]label

### DIFF
--- a/wcsaxes/core.py
+++ b/wcsaxes/core.py
@@ -68,6 +68,7 @@ class WCSAxes(Axes):
 
         if slices is None:
             slices = ('x', 'y')
+        self.slices = slices
 
         # Common default settings for Rectangular Frame
         if self.frame_class is RectangularFrame:
@@ -123,16 +124,16 @@ class WCSAxes(Axes):
         self.coords.frame.draw(renderer)
 
     def set_xlabel(self, label):
-        self.coords[0].set_axislabel(label)
+        self.coords[self.slices.index('x')].set_axislabel(label)
 
     def set_ylabel(self, label):
-        self.coords[1].set_axislabel(label)
+        self.coords[self.slices.index('y')].set_axislabel(label)
 
     def get_xlabel(self):
-        return self.coords[0].get_axislabel()
+        return self.coords[self.slices.index('x')].get_axislabel()
 
     def get_ylabel(self):
-        return self.coords[1].get_axislabel()
+        return self.coords[self.slices.index('y')].get_axislabel()
 
     def get_coords_overlay(self, frame, equinox=None, obstime=None, coord_meta=None):
 


### PR DESCRIPTION
This could use some more improvements, but it makes the set_[xy]label methods
slightly more robust, by selecting the appropriate coordinate helper to label.

Another idea is to override the position of these coordinate labels, to the
bottom/left axes, for further consistence with matplotlib. However, #92 needs to be resolved first
