### PR TITLE
Bad interaction between units and tick labels?

### DIFF
--- a/wcsaxes/formatter_locator.py
+++ b/wcsaxes/formatter_locator.py
@@ -281,7 +281,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
                     precision = 0
                 else:
                     fields = 3
-                    precision = -int(np.floor(np.log10(spacing)))
+                    precision = -int(np.floor(np.log10(spacing.value)))
                 decimal = False
                 unit = u.degree
             else:
@@ -436,7 +436,7 @@ class ScalarFormatterLocator(BaseFormatterLocator):
         if len(values) > 0:
             if self.format is None:
                 if spacing.value < 1.:
-                    precision = -int(np.floor(np.log10(spacing)))
+                    precision = -int(np.floor(np.log10(spacing.value)))
                 else:
                     precision = 0
             elif self.format.startswith('%'):


### PR DESCRIPTION
This is a regression failure of some sort.  I am using matplotlib 1.4, and I think it is responsible for the change in behavior.

I get the following traceback:

```
Traceback (most recent call last):
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/matplotlib/artist.py", line 59, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/Users/adam/anaconda/envs/astropy27/lib/python2.7/site-packages/matplotlib/figure.py", line 1079, in draw
    func(*args)
  File "/Users/adam/repos/wcsaxes/wcsaxes/core.py", line 113, in draw
    ticklabels_bbox=self._ticklabels_bbox)
  File "/Users/adam/repos/wcsaxes/wcsaxes/coordinate_helpers.py", line 335, in _draw
    self._update_ticks(renderer)
  File "/Users/adam/repos/wcsaxes/wcsaxes/coordinate_helpers.py", line 470, in _update_ticks
    text = self._formatter_locator.formatter(self.lbl_world * tick_world_coordinates.unit, spacing=spacing)
  File "/Users/adam/repos/wcsaxes/wcsaxes/formatter_locator.py", line 439, in formatter
    precision = -int(np.floor(np.log10(spacing)))
  File "/Users/adam/repos/astropy/astropy/units/quantity.py", line 282, in __array_prepare__
    scales, result_unit = UFUNC_HELPERS[function](function, *units)
  File "/Users/adam/repos/astropy/astropy/units/quantity_helper.py", line 83, in helper_dimensionless_to_dimensionless
    .format(f.__name__))
TypeError: Can only apply 'log10' function to dimensionless quantities
```

which I think is because of this:

```
> /Users/adam/repos/wcsaxes/wcsaxes/formatter_locator.py(439)formatter()
    438                 if spacing.value < 1.:
--> 439                     precision = -int(np.floor(np.log10(spacing)))
```

which is invalid... it should be `np.log10(spacing.value)`, no?
