### PR TITLE
Fix typo in TestBasic.test_rcparams that caused a fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ wcsaxes/version.py
 .project
 .pydevproject
 .settings
+.idea
 .coverage
-

--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -78,13 +78,13 @@ class CoordinateHelper(object):
             ' ': 'none',
             '': 'none'
         }
-        self.grid_lines_kwargs = {'visible':False,
-                                  'facecolor':'none',
+        self.grid_lines_kwargs = {'visible': False,
+                                  'facecolor': 'none',
                                   'edgecolor': rcParams['grid.color'],
                                   'linestyle': lines_to_patches_linestyle[rcParams['grid.linestyle']],
                                   'linewidth': rcParams['grid.linewidth'],
                                   'alpha': rcParams.get('grid.alpha', 1.0),
-                                  'transform':self.parent_axes.transData}
+                                  'transform': self.parent_axes.transData}
 
     def grid(self, draw_grid=True, grid_type='lines', **kwargs):
         """

--- a/wcsaxes/tests/test_images.py
+++ b/wcsaxes/tests/test_images.py
@@ -229,7 +229,7 @@ class TestBasic(BaseImageTests):
                 'xtick.major.size': 20,
                 'xtick.major.width': 2,
                 'grid.color': 'blue',
-                'grid.linestle': ':.',
+                'grid.linestyle': ':',
                 'grid.linewidth': 1,
                 'grid.alpha': 0.5}):
             fig = plt.figure(figsize=(6, 6))


### PR DESCRIPTION
I got this fail: https://gist.github.com/cdeil/54ee04b65437829bfefc

The attached commit fixes it ... @astrofrog is this the right change?
