### PR TITLE
Plotting onto a WCSAxes using get_transform fails when wcs has >2 axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 
 - Fix compatibility with different versions of Matplotlib. [#153]
 
+- Fix bug when plotting overlays on images with 3+ WCS dimensions.
+
 0.3 (2014-12-07)
 ----------------
 

--- a/wcsaxes/core.py
+++ b/wcsaxes/core.py
@@ -249,12 +249,12 @@ class WCSAxes(Axes):
 
             if coord_in == coord_out:
 
-                return (WCSPixel2WorldTransform(self.wcs)
+                return (WCSPixel2WorldTransform(self.wcs, slice=self.slices)
                         + WCSWorld2PixelTransform(frame))
 
             else:
 
-                return (WCSPixel2WorldTransform(self.wcs)
+                return (WCSPixel2WorldTransform(self.wcs, slice=self.slices)
                         + CoordinateTransform(self.wcs, frame)
                         + WCSWorld2PixelTransform(frame))
 
@@ -264,13 +264,13 @@ class WCSAxes(Axes):
 
         elif isinstance(frame, Transform):
 
-            pixel2world = WCSPixel2WorldTransform(self.wcs)
+            pixel2world = WCSPixel2WorldTransform(self.wcs, slice=self.slices)
 
             return pixel2world + frame
 
         else:
 
-            pixel2world = WCSPixel2WorldTransform(self.wcs)
+            pixel2world = WCSPixel2WorldTransform(self.wcs, slice=self.slices)
 
             if frame == 'world':
 


### PR DESCRIPTION
Hi all,

I am constructing a WCSAxes object like this:

```python
ax_lv = WCSAxes(fig, ax_lv_limits, wcs=self.dendrogram.wcs, slices=('x', 0, 'y')) # `dendrogram` is some object that contains a wcs derived from an (l, b, v) datacube.
fig.add_axes(ax_lv)
```

and then calling "plot" (hoping to plot in coordinate space rather than pixel space) like this:
```python
ax_lv.plot( np.arange(10), transform=ax_lv.get_transform('world') )
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-8a6422a25f67> in <module>()
----> 1 iv.ax_lv.plot(np.arange(10), transform=iv.ax_lv.get_transform('world')
      2 )

/Users/tsrice/Documents/Code/wcsaxes/wcsaxes/core.pyc in get_transform(self, frame, equinox, obstime)
    232                   the specified frame to the pixel/data coordinates.
    233         """
--> 234         return self._get_transform_no_transdata(frame, equinox=equinox, obstime=obstime).inverted() + self.transData
    235
    236     def _get_transform_no_transdata(self, frame, equinox=None, obstime=None):

/Users/tsrice/Documents/Code/wcsaxes/wcsaxes/transforms.pyc in inverted(self)
    170         Return the inverse of the transform
    171         """
--> 172         return WCSWorld2PixelTransform(self.wcs, slice=self.slice)
    173
    174

/Users/tsrice/Documents/Code/wcsaxes/wcsaxes/transforms.pyc in __init__(self, wcs, slice)
     69         if self.wcs.wcs.naxis > 2:
     70             if slice is None:
---> 71                 raise ValueError("WCS has more than 2 dimensions, so ``slice`` should be set")
     72             elif len(slice) != self.wcs.wcs.naxis:
     73                 raise ValueError("slice should have as many elements as WCS "

ValueError: WCS has more than 2 dimensions, so ``slice`` should be set
```        

I then get the above error. I have tried passing `slice` parameters to `get_transform` to no avail. Can I ask if I am using this functionality incorrectly, or if this is a bug?