### PR TITLE
cannot open more than one figure with wcs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 
 - Fix bug when plotting overlays on images with 3+ WCS dimensions.
 
+- Fixed bug that occurred when hovering over an interactive plot before the
+  axes were drawn the first time. [#152]
+
 - Fix bug that occurred in some cases where Matplotlib would try and plot a
   grid as soon as the axes were initialized.
 

--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -174,6 +174,8 @@ class CoordinateHelper(object):
         Given the value of a coordinate, will format it according to the
         format of the formatter_locator.
         """
+        if not hasattr(self, "_fl_spacing"):
+            return ""  # _update_ticks has not been called yet
         fl = self._formatter_locator
         if isinstance(fl, AngleFormatterLocator):
             if self.coord_type == 'longitude':

--- a/wcsaxes/core.py
+++ b/wcsaxes/core.py
@@ -46,8 +46,12 @@ class WCSAxes(Axes):
         self._display_coords_index = 0
         fig.canvas.mpl_connect('key_press_event', self._set_cursor_prefs)
         self.patch = self.coords.frame.patch
+        self._drawn = False
 
     def _display_world_coords(self, x, y):
+
+        if not self._drawn:
+            return ""
 
         if self._display_coords_index == -1:
             return "%s %s (pixel)" % (x, y)
@@ -164,6 +168,8 @@ class WCSAxes(Axes):
                                        visible_ticks=visible_ticks)
 
         self.coords.frame.draw(renderer)
+
+        self._drawn = True
 
     def set_xlabel(self, label):
         self.coords[self._x_index].set_axislabel(label)

--- a/wcsaxes/tests/test_misc.py
+++ b/wcsaxes/tests/test_misc.py
@@ -8,3 +8,18 @@ def test_grid_regression():
     plt.rc('axes', grid=True)
     fig = plt.figure(figsize=(3, 3))
     WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+
+
+def test_format_coord_regression(tmpdir):
+    # Regression test for a bug that meant that if format_coord was called by
+    # Matplotlib before the axes were drawn, an error occurred.
+    fig = plt.figure(figsize=(3, 3))
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+    fig.add_axes(ax)
+    assert ax.format_coord(10,10) == ""
+    assert ax.coords[0].format_coord(10) == ""
+    assert ax.coords[1].format_coord(10) == ""
+    fig.savefig(tmpdir.join('nothing').strpath)
+    assert ax.format_coord(10,10) == "11.0 11.0 (world)"
+    assert ax.coords[0].format_coord(10) == "10.0"
+    assert ax.coords[1].format_coord(10) == "10.0"


### PR DESCRIPTION
Every time I try to open a second figure, I get this:

```
IPython 2.2.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.       
%quickref -> Quick reference.                                       
help      -> Python's own help system.                              
object?   -> Details about 'object', use 'object??' for extra details.
Using matplotlib backend: Qt4Agg                                      

In [1]: from wcsaxes import datasets, WCS

In [2]: 

In [2]: hdu = datasets.fetch_msx_hdu()
WARNING: VerifyWarning: Invalid 'BLANK' keyword in header.  The 'BLANK' keyword is only applicable to integer data, and will be ignored in this HDU. [astropy.io.fits.hdu.image]                          

In [3]: wcs = WCS(hdu.header)

In [4]: import matplotlib.pyplot as plt

In [5]: fig = plt.figure()

In [6]: ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)

In [7]: fig2 = plt.figure()

In [8]: ax2 = fig2.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)

In [9]: Traceback (most recent call last):
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py", line 282, in mouseMoveEvent                                                                    
    FigureCanvasBase.motion_notify_event(self, x, y)                                                 
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 1917, in motion_notify_event                                                                     
    self.callbacks.process(s, event)                                                                 
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.py", line 533, in process                                                                                          
    proxy(*args, **kwargs)                                                                           
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.py", line 408, in __call__                                                                                         
    return mtd(*args, **kwargs)                                                                      
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 2761, in mouse_move                                                                              
    s = event.inaxes.format_coord(event.xdata, event.ydata)                                          
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/core.py", line 61, in _display_world_coords                                                    
    xw = coords[self._x_index].format_coord(world[self._x_index])                                    
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/coordinate_helpers.py", line 183, in format_coord                                              
    spacing = self._fl_spacing                                                                       
AttributeError: 'CoordinateHelper' object has no attribute '_fl_spacing'                             

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues              
or send an email to the mailing list at ipython-dev@scipy.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.                                                   

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True                              

Traceback (most recent call last):
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py", line 282, in mouseMoveEvent                                                                    
    FigureCanvasBase.motion_notify_event(self, x, y)                                                 
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 1917, in motion_notify_event                                                                     
    self.callbacks.process(s, event)                                                                 
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.py", line 533, in process                                                                                          
    proxy(*args, **kwargs)                                                                           
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.py", line 408, in __call__                                                                                         
    return mtd(*args, **kwargs)                                                                      
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 2761, in mouse_move                                                                              
    s = event.inaxes.format_coord(event.xdata, event.ydata)                                          
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/core.py", line 61, in _display_world_coords                                                    
    xw = coords[self._x_index].format_coord(world[self._x_index])                                    
  File "/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/coordinate_helpers.py", line 183, in format_coord                                              
    spacing = self._fl_spacing                                                                       
AttributeError: 'CoordinateHelper' object has no attribute '_fl_spacing'                             

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues              
or send an email to the mailing list at ipython-dev@scipy.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True

%tb
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.pyc in motion_notify_event(self, x, y, guiEvent)
   1915         event = MouseEvent(s, self, x, y, self._button, self._key,
   1916                            guiEvent=guiEvent)
-> 1917         self.callbacks.process(s, event)
   1918
   1919     def leave_notify_event(self, guiEvent=None):

/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.pyc in process(self, s, *args, **kwargs)
    531                     del self.callbacks[s][cid]
    532                 else:
--> 533                     proxy(*args, **kwargs)
    534
    535

/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/cbook.pyc in __call__(self, *args, **kwargs)
    406             mtd = self.func
    407         # invoke the callable and return the result
--> 408         return mtd(*args, **kwargs)
    409
    410     def __eq__(self, other):

/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/matplotlib/backend_bases.pyc in mouse_move(self, event)
   2759
   2760             try:
-> 2761                 s = event.inaxes.format_coord(event.xdata, event.ydata)
   2762             except (ValueError, OverflowError):
   2763                 pass

/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/core.pyc in _display_world_coords(self, x, y)
     59         world = coords._transform.transform(np.array([pixel]))[0]
     60
---> 61         xw = coords[self._x_index].format_coord(world[self._x_index])
     62         yw = coords[self._y_index].format_coord(world[self._y_index])
     63

/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/wcsaxes-0.4.dev506-py2.7.egg/wcsaxes/coordinate_helpers.pyc in format_coord(self, value)
    181             value = value * u.degree
    182             value = value.to(fl._unit).value
--> 183         spacing = self._fl_spacing
    184         string = fl.formatter(values=[value] * fl._unit, spacing=spacing)
    185         return string[0]

AttributeError: 'CoordinateHelper' object has no attribute '_fl_spacing'

```