### PR TITLE
RuntimeWarning from reproject HEALPIX plotting example

### DIFF
--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -469,8 +469,9 @@ class CoordinateHelper(object):
             tick_angle = np.degrees(np.arctan2(dy, dx))
 
             normal_angle_full = np.hstack([spine.normal_angle, spine.normal_angle[-1]])
-            reset = (((normal_angle_full - tick_angle) % 360 > 90.) &
-                     ((tick_angle - normal_angle_full) % 360 > 90.))
+            with np.errstate(invalid='ignore'):
+                reset = (((normal_angle_full - tick_angle) % 360 > 90.) &
+                         ((tick_angle - normal_angle_full) % 360 > 90.))
             tick_angle[reset] -= 180.
 
             # We find for each interval the starting and ending coordinate,
@@ -481,8 +482,9 @@ class CoordinateHelper(object):
             if self.coord_type == 'longitude':
                 w1 = wrap_angle_at(w1, self.coord_wrap)
                 w2 = wrap_angle_at(w2, self.coord_wrap)
-                w1[w2 - w1 > 180.] += 360
-                w2[w1 - w2 > 180.] += 360
+                with np.errstate(invalid='ignore'):
+                    w1[w2 - w1 > 180.] += 360
+                    w2[w1 - w2 > 180.] += 360
 
             # For longitudes, we need to check ticks as well as ticks + 360,
             # since the above can produce pairs such as 359 to 361 or 0.5 to
@@ -511,8 +513,9 @@ class CoordinateHelper(object):
             # separately for the case where the tick falls exactly on the
             # frame points, otherwise we'll get two matches, one for w1 and
             # one for w2.
-            intersections = np.hstack([np.nonzero((t - w1) == 0)[0],
-                                       np.nonzero(((t - w1) * (t - w2)) < 0)[0]])
+            with np.errstate(invalid='ignore'):
+                intersections = np.hstack([np.nonzero((t - w1) == 0)[0],
+                                           np.nonzero(((t - w1) * (t - w2)) < 0)[0]])
 
             # But we also need to check for intersection with the last w2
             if t - w2[-1] == 0:

--- a/wcsaxes/grid_paths.py
+++ b/wcsaxes/grid_paths.py
@@ -37,9 +37,11 @@ def get_lon_lat_path(lon_lat, pixel, lon_lat_check):
                              np.radians(lon_lat_check[:, 0]),
                              np.radians(lon_lat_check[:, 1]))
 
-    sep[sep > np.pi] -= 2. * np.pi
+    with np.errstate(invalid='ignore'):
 
-    mask = np.abs(sep > ROUND_TRIP_TOL)
+        sep[sep > np.pi] -= 2. * np.pi
+
+        mask = np.abs(sep > ROUND_TRIP_TOL)
 
     # Mask values with invalid pixel positions
     mask = mask | np.isnan(pixel[:, 0]) | np.isnan(pixel[:, 1])

--- a/wcsaxes/tests/test_misc.py
+++ b/wcsaxes/tests/test_misc.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -61,5 +63,9 @@ def test_no_numpy_warnings():
     with catch_warnings() as ws:
         ax.coords.frame.set_color('none')
         plt.savefig('test.png')
+
+    # For debugging
+    for w in ws:
+        print(w)
 
     assert len(ws) == 0

--- a/wcsaxes/tests/test_misc.py
+++ b/wcsaxes/tests/test_misc.py
@@ -1,4 +1,11 @@
+import numpy as np
 import matplotlib.pyplot as plt
+
+from astropy.wcs import WCS
+from astropy.io import fits
+from astropy.tests.helper import catch_warnings
+
+
 from ..core import WCSAxes
 
 
@@ -23,3 +30,36 @@ def test_format_coord_regression(tmpdir):
     assert ax.format_coord(10,10) == "11.0 11.0 (world)"
     assert ax.coords[0].format_coord(10) == "10.0"
     assert ax.coords[1].format_coord(10) == "10.0"
+
+
+TARGET_HEADER = fits.Header.fromstring("""
+NAXIS   =                    2
+NAXIS1  =                  200
+NAXIS2  =                  100
+CTYPE1  = 'RA---MOL'
+CRPIX1  =                  500
+CRVAL1  =                180.0
+CDELT1  =                 -0.4
+CUNIT1  = 'deg     '
+CTYPE2  = 'DEC--MOL'
+CRPIX2  =                  400
+CRVAL2  =                  0.0
+CDELT2  =                  0.4
+CUNIT2  = 'deg     '
+COORDSYS= 'icrs    '
+""", sep='\n')
+
+def test_no_numpy_warnings():
+
+    # Make sure that no warnings are raised if some pixels are outside WCS
+    # (since this is normal/)
+
+    ax = plt.subplot(1,1,1, projection=WCS(TARGET_HEADER))
+    ax.imshow(np.zeros((100,200)))
+    ax.coords.grid(color='white')
+
+    with catch_warnings() as ws:
+        ax.coords.frame.set_color('none')
+        plt.savefig('test.png')
+
+    assert len(ws) == 0

--- a/wcsaxes/tests/test_misc.py
+++ b/wcsaxes/tests/test_misc.py
@@ -54,14 +54,13 @@ COORDSYS= 'icrs    '
 def test_no_numpy_warnings():
 
     # Make sure that no warnings are raised if some pixels are outside WCS
-    # (since this is normal/)
+    # (since this is normal)
 
     ax = plt.subplot(1,1,1, projection=WCS(TARGET_HEADER))
     ax.imshow(np.zeros((100,200)))
     ax.coords.grid(color='white')
 
     with catch_warnings() as ws:
-        ax.coords.frame.set_color('none')
         plt.savefig('test.png')
 
     # For debugging

--- a/wcsaxes/transforms.py
+++ b/wcsaxes/transforms.py
@@ -168,7 +168,8 @@ class WCSPixel2WorldTransform(CurvedTransform):
         # At the moment, one has to manually check that the transformation
         # round-trips, otherwise it should be considered invalid.
         pixel_check = self.wcs.wcs_world2pix(world, 1)
-        invalid = np.any(np.abs(pixel_check - pixel_full) > 1., axis=1)
+        with np.errstate(invalid='ignore'):
+            invalid = np.any(np.abs(pixel_check - pixel_full) > 1., axis=1)
         world[invalid] = np.nan
 
         return world


### PR DESCRIPTION
As mentioned at https://github.com/astrofrog/reproject/issues/75#issuecomment-99777214 , the HEALPIX plotting example in the reproject docs (see http://reproject.readthedocs.org/en/latest/healpix.html) raises a bunch of RunTimeWarnings in wcsaxes:
```
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/transforms.py:171: RuntimeWarning: invalid value encountered in greater
  invalid = np.any(np.abs(pixel_check - pixel_full) > 1., axis=1)
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_range.py:50: RuntimeWarning: invalid value encountered in greater
  reset = np.abs(wjump) > 180.
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_range.py:58: RuntimeWarning: invalid value encountered in greater
  reset = np.abs(wjump) > 180.
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_range.py:11: RuntimeWarning: invalid value encountered in greater
  values_new[values_new > 180.] -= 360
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_helpers.py:470: RuntimeWarning: invalid value encountered in greater
  reset = (((normal_angle_full - tick_angle) % 360 > 90.) &
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_helpers.py:471: RuntimeWarning: invalid value encountered in greater
  ((tick_angle - normal_angle_full) % 360 > 90.))
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_helpers.py:482: RuntimeWarning: invalid value encountered in greater
  w1[w2 - w1 > 180.] += 360
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_helpers.py:483: RuntimeWarning: invalid value encountered in greater
  w2[w1 - w2 > 180.] += 360
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/coordinate_helpers.py:513: RuntimeWarning: invalid value encountered in less
  np.nonzero(((t - w1) * (t - w2)) < 0)[0]])
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/grid_paths.py:40: RuntimeWarning: invalid value encountered in greater
  sep[sep > np.pi] -= 2. * np.pi
/Users/deil/Library/Python/3.4/lib/python/site-packages/wcsaxes-0.4.dev512-py3.4.egg/wcsaxes/grid_paths.py:42: RuntimeWarning: invalid value encountered in greater
  mask = np.abs(sep > ROUND_TRIP_TOL)
```

See http://nbviewer.ipython.org/gist/cdeil/4bc69590a4c60119ae70

Is it possible to fix those?
Or is it a good idea to suppress them?