### PR TITLE
When trying to create an overlay from a non-existent frame a crazy error is raised.

### DIFF
--- a/wcsaxes/tests/test_misc.py
+++ b/wcsaxes/tests/test_misc.py
@@ -5,10 +5,10 @@ import matplotlib.pyplot as plt
 
 from astropy.wcs import WCS
 from astropy.io import fits
-from astropy.tests.helper import catch_warnings
-
+from astropy.tests.helper import catch_warnings, pytest
 
 from ..core import WCSAxes
+from ..utils import get_coord_meta
 
 
 def test_grid_regression():
@@ -68,3 +68,16 @@ def test_no_numpy_warnings():
         print(w)
 
     assert len(ws) == 0
+
+
+def test_invalid_frame_overlay():
+
+    # Make sure a nice error is returned if a frame doesn't exist
+    ax = plt.subplot(1,1,1, projection=WCS(TARGET_HEADER))
+    with pytest.raises(ValueError) as exc:
+        ax.get_coords_overlay('banana')
+    assert exc.value.args[0] == 'Unknown frame: banana'
+
+    with pytest.raises(ValueError) as exc:
+        get_coord_meta('banana')
+    assert exc.value.args[0] == 'Unknown frame: banana'

--- a/wcsaxes/utils.py
+++ b/wcsaxes/utils.py
@@ -106,7 +106,10 @@ def get_coord_meta(frame):
         from astropy.coordinates import frame_transform_graph
 
         if isinstance(frame, six.string_types):
+            initial_frame = frame
             frame = frame_transform_graph.lookup_name(frame)
+            if frame is None:
+                raise ValueError("Unknown frame: {0}".format(initial_frame))
 
         if not isinstance(frame, BaseCoordinateFrame):
             frame = frame()


### PR DESCRIPTION
```python
/home/stuart/GitHub/sunpy/sunpy/visualization/wcsaxes_compat.py in wcsaxes_heliographic_overlay(axes)
     82     """
     83     Draw a heliographic overlay using wcsaxes
     84     """
---> 85     overlay = axes.get_coords_overlay('heliographicstonyhurst')
     86 
     87     lon = overlay[0]

/opt/miniconda/envs/sunpy-dev/lib/python2.7/site-packages/wcsaxes/core.pyc in get_coords_overlay(self, frame, equinox, obstime, coord_meta)
    186         else:
    187             if coord_meta is None:
--> 188                 coord_meta = get_coord_meta(frame)
    189             transform = self._get_transform_no_transdata(frame, equinox=equinox, obstime=obstime)
    190             coords = CoordinatesMap(self, transform=transform, coord_meta=coord_meta, frame_class=self.frame_class)

/opt/miniconda/envs/sunpy-dev/lib/python2.7/site-packages/wcsaxes/utils.pyc in get_coord_meta(frame)
    108             frame = frame_transform_graph.lookup_name(frame)
    109 
--> 110         names = list(frame().representation_component_names.keys())
    111         coord_meta['name'] = names[:2]
    112 

TypeError: 'NoneType' object is not callable
```

This should probably exit more gracefully than this.