### PR TITLE
Methods for setting tick/tick label visibility

### DIFF
--- a/docs/ticks_labels_grid.rst
+++ b/docs/ticks_labels_grid.rst
@@ -258,6 +258,43 @@ We can set the defaults back using:
     lat.set_axislabel_position('l')
 
 
+Hiding ticks and tick labels
+============================
+
+Sometimes it's desirable to hide ticks and tick labels. A common scenario
+is where WCSAxes is being used in a grid of subplots and the tick labels
+are redundant across rows or columns. Tick labels and ticks can be hidden with
+the :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticklabel_visible`
+and :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks_visible`
+methods, respectively:
+
+.. plot::
+   :context:
+   :include-source:
+   :align: center
+
+    lon.set_ticks_visible(False)
+    lon.set_ticklabel_visible(False)
+    lat.set_ticks_visible(False)
+    lat.set_ticklabel_visible(False)
+    lon.set_axislabel('')
+    lat.set_axislabel('')
+
+And we can restore the ticks and tick labels again using:
+
+.. plot::
+   :context:
+   :include-source:
+   :align: center
+
+    lon.set_ticks_visible(True)
+    lon.set_ticklabel_visible(True)
+    lat.set_ticks_visible(True)
+    lat.set_ticklabel_visible(True)
+    lon.set_axislabel('Galactic Longitude')
+    lat.set_axislabel('Galactic Latitude')
+
+
 Coordinate grid
 ===============
 

--- a/docs/ticks_labels_grid.rst
+++ b/docs/ticks_labels_grid.rst
@@ -223,7 +223,7 @@ Tick, tick label, and axis label position
 
 By default, the tick and axis labels for the first coordinate are shown on the
 x-axis, and the tick and axis labels for the second coordinate are shown on
-the y-axis. In addition, the ticks for both coordintes are shown on all axes.
+the y-axis. In addition, the ticks for both coordinates are shown on all axes.
 This can be customized using the
 :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks_position` and
 :meth:`~wcsaxes.coordinate_helpers.CoordinateHelper.set_ticklabel_position` methods, which each
@@ -243,7 +243,7 @@ right, or top axes respectively):
     lat.set_ticklabel_position('lr')
     lat.set_axislabel_position('lr')
 
-we can set the defaults back using:
+We can set the defaults back using:
 
 .. plot::
    :context:

--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -292,6 +292,18 @@ class CoordinateHelper(object):
         """
         self.ticks.set_visible_axes(position)
 
+    def set_ticks_visible(self, visible):
+        """
+        Set whether ticks are visible or not.
+
+        Parameters
+        ----------
+        visible : bool
+            The visibility of ticks. Setting as ``False`` will hide ticks
+            along this coordinate.
+        """
+        self.ticks.set_visible(visible)
+
     def set_ticklabel(self, **kwargs):
         """
         Set the visual properties for the tick labels.
@@ -318,6 +330,18 @@ class CoordinateHelper(object):
             tick labels to be shown on the left and bottom axis.
         """
         self.ticklabels.set_visible_axes(position)
+
+    def set_ticklabel_visible(self, visible):
+        """
+        Set whether the tick labels are visible or not.
+
+        Parameters
+        ----------
+        visible : bool
+            The visibility of ticks. Setting as ``False`` will hide this
+            coordinate's tick labels.
+        """
+        self.ticklabels.set_visible(visible)
 
     def set_axislabel(self, text, minpad=1, **kwargs):
         """


### PR DESCRIPTION
Add `set_ticks_visible` and `set_ticklabel_visible` methods to toggle tick and tick label visibility. Includes a new section in the ticks/tick label documentation page.

Fixes #169.