### PR TITLE
Fix adjustable datalim draw

### DIFF
--- a/wcsaxes/core.py
+++ b/wcsaxes/core.py
@@ -188,6 +188,16 @@ class WCSAxes(Axes):
 
     def draw(self, renderer, inframe=False):
 
+        # In Axes.draw, the following code can result in the xlim and ylim
+        # values changing, so we need to force call this here to make sure that
+        # the limits are correct before we update the patch.
+        locator = self.get_axes_locator()
+        if locator:
+            pos = locator(self, renderer)
+            self.apply_aspect(pos)
+        else:
+            self.apply_aspect()
+
         # We need to make sure that that frame path is up to date
         self.coords.frame._update_patch_path()
 


### PR DESCRIPTION
In cases where the user has adjustable=‘datalim’, the limits of the axes can change between draws. However, the limits returned by xlim and ylim are only re-computed inside Axes.draw, so when we update the patch, we are not using the latest limits. We now run the same code as in Axes.draw to make sure that we are using the latest limits.