### PR TITLE
Feature: An easy way to make a `wcsaxes.WCS` from an `astropy.wcs.WCS` object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 - Fix bug that caused coordinate transformations to not work properly if they
   used sub-classes of Spherical representation classes. [#177]
 
+- Updated documentation to show that the Astropy WCS class can now be used
+  directly. [#186]
+
 0.6 (2015-07-20)
 ----------------
 

--- a/docs/controlling_axes.rst
+++ b/docs/controlling_axes.rst
@@ -14,8 +14,8 @@ can change the unit to an equivalent one by:
    :context: reset
    :nofigs:
 
-
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
 
     hdu = datasets.fetch_l1448_co_hdu()
     wcs = WCS(hdu.header)

--- a/docs/custom_frames.rst
+++ b/docs/custom_frames.rst
@@ -12,7 +12,8 @@ following example shows how to use the built-in
    :include-source:
    :align: center
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
     from wcsaxes.frame import EllipticalFrame
 
     hdu = datasets.fetch_msx_hdu()
@@ -73,7 +74,8 @@ which we can then use:
     :include-source:
     :align: center
 
-     from wcsaxes import datasets, WCS
+     from astropy.wcs import WCS
+     from wcsaxes import datasets
 
      hdu = datasets.fetch_msx_hdu()
      wcs = WCS(hdu.header)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,7 +17,8 @@ information. In this example, we will use a FITS file from the
    :include-source:
    :align: center
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
 
     hdu = datasets.fetch_msx_hdu()
     wcs = WCS(hdu.header)
@@ -40,10 +41,6 @@ We then create a figure using Matplotlib and create the axes using the
     import matplotlib.pyplot as plt
     fig = plt.figure()
     ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)
-
-.. note:: If you are using Matplotlib <=1.1 then the ``projection=`` functionality
-          does not exist and one should use the alternative shown
-          in :ref:`initialize_alternative`
 
 The ``ax`` object created is an instance of the :class:`~wcsaxes.WCSAxes`
 class. For more information about the different ways of initializing axes,

--- a/docs/initializing_axes.rst
+++ b/docs/initializing_axes.rst
@@ -10,7 +10,7 @@ simplest way is to make use of the :class:`wcsaxes.WCS` class (instead of
 :class:`astropy.wcs.WCS`) and pass this to the
 :meth:`~matplotlib.figure.Figure.add_subplot` method::
 
-    from wcsaxes import WCS
+    from astropy.wcs import WCS
     import matplotlib.pyplot as plt
     
     wcs = WCS(...)
@@ -35,10 +35,10 @@ or::
 
     plt.axes([0.1, 0.1, 0.8, 0.8], projection=wcs)
 
-In the above examples, and in the rest of the documentation, we use the
-:class:`wcsaxes.WCS` class, which is almost identical to
-:class:`astropy.wcs.WCS` but includes a couple of additional methods that are
-needed to allow us to use the matplotlib ``projection=`` option.
+Note that in the above example, there is no explicit call to the ``wcsaxes``
+package. This is because the :class:`astropy.wcs.WCS` class knows about
+``wcsaxes``, and is able to automatically instantiate a
+:class:`wcsaxes.WCSAxes` object.
 
 Note that any additional arguments passed to
 :meth:`~matplotlib.figure.Figure.add_subplot`,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ packages to be installed:
 
 * `Numpy <http://www.numpy.org>`_
 
-* `Matplotlib <http://www.matplotlib.org>`_
+* `Matplotlib <http://www.matplotlib.org>`_ 1.1 or later
 
 * `Astropy <http://www.astropy.org>`__ 1.0 or later
 

--- a/docs/overlaying_coordinate_systems.rst
+++ b/docs/overlaying_coordinate_systems.rst
@@ -9,7 +9,8 @@ For the example in the following page we start from the example introduced in
    :context: reset
    :nofigs:
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
 
     hdu = datasets.fetch_msx_hdu()
     wcs = WCS(hdu.header)

--- a/docs/overlays.rst
+++ b/docs/overlays.rst
@@ -9,7 +9,8 @@ For the example in the following page we start from the example introduced in
    :context: reset
    :nofigs:
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
 
     hdu = datasets.fetch_msx_hdu()
     wcs = WCS(hdu.header)

--- a/docs/slicing_datacubes.rst
+++ b/docs/slicing_datacubes.rst
@@ -22,7 +22,8 @@ information. The original FITS file can be downloaded from `here
    :align: center
    :nofigs:
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
     hdu = datasets.fetch_l1448_co_hdu()
     wcs = WCS(hdu.header)
     image_data = hdu.data

--- a/docs/ticks_labels_grid.rst
+++ b/docs/ticks_labels_grid.rst
@@ -9,7 +9,8 @@ For the example in the following page we start from the example introduced in
    :context: reset
    :nofigs:
 
-    from wcsaxes import datasets, WCS
+    from astropy.wcs import WCS
+    from wcsaxes import datasets
 
     hdu = datasets.fetch_msx_hdu()
     wcs = WCS(hdu.header)

--- a/wcsaxes/tests/test_images.py
+++ b/wcsaxes/tests/test_images.py
@@ -12,10 +12,11 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.tests.helper import pytest
 from astropy.tests.helper import remote_data
+from astropy.wcs import WCS
 
 from ..rc_utils import rc_context
 
-from .. import datasets, WCS, WCSAxes
+from .. import datasets, WCSAxes
 
 
 class BaseImageTests(object):

--- a/wcsaxes/wcs_wrapper.py
+++ b/wcsaxes/wcs_wrapper.py
@@ -1,20 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 from astropy.wcs import WCS as AstropyWCS
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .core import WCSAxes
 
 
-# The purpose of the following class is to implement the ``_as_mpl_axes`` method
-# which allows us to use the ``projection=`` API for Matplotlib. Once WCSAxes is
-# merged into Astropy, we can just add this method directly to the 'real' WCS
-# class.
-
 class WCS(AstropyWCS):
 
-    def _as_mpl_axes(self):
-        return WCSAxes, {'wcs': self}
-
-    def __iter__(self):
-        # Backport of astropy/astropy#3066
-        raise TypeError("'{0}' object is not iterable".format(self.__class__.__name__))
+    def __init__(self, *args, **kwargs):
+        warnings.warn("The wcsaxes.WCS class has been deprecated - use "
+                      "astropy.wcs.WCS instead", AstropyDeprecationWarning)


### PR DESCRIPTION
The best way I can come up with is
```
ax = fig.add_subplot(1, 1 ,1 , projection=wcsaxes.WCS(astropywcs.to_header()))
```
Maybe this issue will solve itself when this is merged into astropy by just adding the required methods to the astropy WCS.
Until then (unless that happens soon), it would be nice to accept an `astropy.wcs.WCS` to initialize a WCS like so: `wcsaxes.WCS(astropywcsinstance)`.

It's not so much the extra typing, but the fast that it took me almost an hour to discover this (or maybe I'm just dumb).