### PR TITLE
Make sure wrap_angle_at doesn’t emit any warnings on ARM processors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Updated documentation to show that the Astropy WCS class can now be used
   directly. [#186]
 
+- Make sure wrap_angle_at doesn’t emit any warnings on ARM processors. [#196]
+
 0.6 (2015-07-20)
 ----------------
 

--- a/wcsaxes/coordinate_helpers.py
+++ b/wcsaxes/coordinate_helpers.py
@@ -25,7 +25,10 @@ __all__ = ['CoordinateHelper']
 
 
 def wrap_angle_at(values, coord_wrap):
-    return np.mod(values - coord_wrap, 360.) - (360. - coord_wrap)
+    # On ARM processors, np.mod emits warnings if there are NaN values in the
+    # array, although this doesn't seem to happen on other processors.
+    with np.errstate(invalid='ignore'):
+        return np.mod(values - coord_wrap, 360.) - (360. - coord_wrap)
 
 
 class CoordinateHelper(object):


### PR DESCRIPTION
Fixes https://github.com/astrofrog/wcsaxes/issues/181

(I managed to reproduce the issue on my raspberry pi!)