### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
         - PIP_DEPENDENCIES='pytest-mpl'
         - SETUP_XVFB=True
         - SETUP_CMD='test --remote-data'
+        - CONDA_CHANNELS='astropy-ci-extras'
+
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='test --remote-data'


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add ``astropy`` and ``astropy-ci-extras`` by default in the future https://github.com/astropy/ci-helpers/pull/128.